### PR TITLE
Add LaravelMiddleware - fixes events dispatching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo_sqlite, bcmath, intl, exif, iconv, fileinfo
           coverage: none
 
       - name: Setup problem matchers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.2]
-        laravel: [9.*, 10.x]
-        stability: [prefer-lowest, prefer-stable]
+        os: [ ubuntu-latest, windows-latest ]
+        php: [ 8.1, 8.2 ]
+        laravel: [ 9.*, 10.* ]
+        stability: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 9.*
             testbench: 7.*

--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -31,7 +31,7 @@ class HttpSender extends GuzzleSender
     protected LaravelMiddleware $laravelMiddleware;
 
     /**
-     * Constructorπ
+     * Constructor
      *
      * Create the HTTP client.
      */

--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -24,13 +24,6 @@ use Illuminate\Http\Client\RequestException as HttpRequestException;
 class HttpSender extends GuzzleSender
 {
     /**
-     * Denotes if we have registered the Laravel's default handlers onto the client.
-     *
-     * @var bool
-     */
-    protected bool $hasRegisteredDefaultHandlers = false;
-
-    /**
      * Guzzle middleware used to handle Laravel's Pending Request.
      *
      * @var \Saloon\HttpSender\LaravelMiddleware

--- a/src/LaravelMiddleware.php
+++ b/src/LaravelMiddleware.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Saloon\HttpSender;
 
 use GuzzleHttp\HandlerStack;
+use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\PendingRequest;
 
 class LaravelMiddleware
@@ -18,18 +20,24 @@ class LaravelMiddleware
 
     /**
      * Invoke the middleware.
+     *
+     * @param callable $handler
+     * @return callable
      */
-    public function __invoke($handler)
+    public function __invoke(callable $handler): callable
     {
-        return function ($request, $options) use ($handler) {
+        return function ($request, $options) use ($handler): ResponseInterface|PromiseInterface {
             return $this->pendingRequest->pushHandlers(new HandlerStack($handler))->__invoke($request, $options);
         };
     }
 
     /**
      * Set the current pending request.
+     *
+     * @param \Illuminate\Http\Client\PendingRequest $pendingRequest
+     * @return void
      */
-    public function setRequest(PendingRequest $pendingRequest)
+    public function setRequest(PendingRequest $pendingRequest): void
     {
         $this->pendingRequest = $pendingRequest;
     }

--- a/src/LaravelMiddleware.php
+++ b/src/LaravelMiddleware.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\HttpSender;
+
+use GuzzleHttp\HandlerStack;
+use Illuminate\Http\Client\PendingRequest;
+
+class LaravelMiddleware
+{
+    /**
+     * The current pending request.
+     *
+     * @var \Illuminate\Http\Client\PendingRequest
+     */
+    protected PendingRequest $pendingRequest;
+
+    /**
+     * Invoke the middleware.
+     */
+    public function __invoke($handler)
+    {
+        return function ($request, $options) use ($handler) {
+            return $this->pendingRequest->pushHandlers(new HandlerStack($handler))->__invoke($request, $options);
+        };
+    }
+
+    /**
+     * Set the current pending request.
+     */
+    public function setRequest(PendingRequest $pendingRequest)
+    {
+        $this->pendingRequest = $pendingRequest;
+    }
+}

--- a/tests/Feature/HttpEventsTest.php
+++ b/tests/Feature/HttpEventsTest.php
@@ -26,7 +26,7 @@ test('the http events are fired when using the http sender', function () {
 
     Event::assertDispatched(RequestSending::class, 3);
     Event::assertDispatched(ResponseReceived::class, 3);
-})->skip();
+});
 
 test('the http events are fired when using the http sender with asynchronous events', function () {
     Config::set('saloon.default_sender', HttpSender::class);
@@ -44,4 +44,4 @@ test('the http events are fired when using the http sender with asynchronous eve
 
     Event::assertDispatched(RequestSending::class, 3);
     Event::assertDispatched(ResponseReceived::class, 3);
-})->skip();
+});

--- a/tests/Feature/HttpEventsTest.php
+++ b/tests/Feature/HttpEventsTest.php
@@ -16,6 +16,7 @@ test('the http events are fired when using the http sender', function () {
     Event::fake();
 
     $connector = new HttpSenderConnector;
+
     $responseA = $connector->send(new UserRequest);
     $responseB = $connector->send(new UserRequest);
     $responseC = $connector->send(new UserRequest);
@@ -34,6 +35,7 @@ test('the http events are fired when using the http sender with asynchronous eve
     Event::fake();
 
     $connector = new HttpSenderConnector;
+
     $responseA = $connector->sendAsync(new UserRequest)->wait();
     $responseB = $connector->sendAsync(new UserRequest)->wait();
     $responseC = $connector->sendAsync(new UserRequest)->wait();

--- a/tests/Feature/HttpEventsTest.php
+++ b/tests/Feature/HttpEventsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Saloon\Contracts\Response;
 use Saloon\HttpSender\HttpSender;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
@@ -16,6 +17,8 @@ test('the http events are fired when using the http sender', function () {
     Event::fake();
 
     $connector = new HttpSenderConnector;
+
+    expect($connector->sender())->toBeInstanceOf(HttpSender::class);
 
     $responseA = $connector->send(new UserRequest);
     $responseB = $connector->send(new UserRequest);
@@ -36,6 +39,8 @@ test('the http events are fired when using the http sender with asynchronous eve
 
     $connector = new HttpSenderConnector;
 
+    expect($connector->sender())->toBeInstanceOf(HttpSender::class);
+
     $responseA = $connector->sendAsync(new UserRequest)->wait();
     $responseB = $connector->sendAsync(new UserRequest)->wait();
     $responseC = $connector->sendAsync(new UserRequest)->wait();
@@ -43,6 +48,37 @@ test('the http events are fired when using the http sender with asynchronous eve
     expect($responseA->status())->toBe(200);
     expect($responseB->status())->toBe(200);
     expect($responseC->status())->toBe(200);
+
+    Event::assertDispatched(RequestSending::class, 3);
+    Event::assertDispatched(ResponseReceived::class, 3);
+});
+
+test('the http events are fired when using request pools', function () {
+    Config::set('saloon.default_sender', HttpSender::class);
+
+    Event::fake();
+
+    $connector = new HttpSenderConnector;
+
+    expect($connector->sender())->toBeInstanceOf(HttpSender::class);
+
+    $pool = $connector->pool([
+        'a' => new UserRequest,
+        'b' => new UserRequest,
+        'c' => new UserRequest,
+    ]);
+
+    $responses = [];
+
+    $pool->withResponseHandler(function (Response $response, string $key) use (&$responses) {
+        $responses[$key] = $response;
+    });
+
+    $pool->send()->wait();
+
+    expect($responses['a']->status())->toBe(200);
+    expect($responses['b']->status())->toBe(200);
+    expect($responses['c']->status())->toBe(200);
 
     Event::assertDispatched(RequestSending::class, 3);
     Event::assertDispatched(ResponseReceived::class, 3);


### PR DESCRIPTION
Hi,

first of all, thanks for creating Saloon, I love it. We've just adopted v2 in a project and the experience has been great so far!  One bug I've noticed while debugging the requests in Telescope is that only the first request is logged for every connector. This behaviour is related to the failing tests in the HttpEvents test case.

### TLDR

I added a new guzzle middleware that pipes every request though it's related PendingRequest handler stack as these are bound. Tests are passing and Telescope now properly logs every request ✅


### Problem

After some digging, I found that this is caused by the Laravel's handlers being being bound to the PendingRequest instance. Inside the HttpSender, before sending the first request, handlers from PendingRequest are pushed onto the underlying guzzle handler stack. Then when sending subsequent requests, these handlers are still interacting with the first PendingRequest instance that was built inside the sender.

To fully understand this, let's look at the Laravel PendingRequest constructor:

```php
public function __construct(Factory $factory = null)
{
    // ...

    $this->beforeSendingCallbacks = collect([function (...) {
        $pendingRequest->request = $request;

        // ...
    }]);
}
```

Laravel adds a default beforeSending callback that assigns the current guzzle request to the current PendingRequest instance. This is then checked after receiving a response in the `dispatchResponseReceivedEvent`:

```php
protected function dispatchResponseReceivedEvent(Response $response)
{
    if (... || ! $this->request) {
        return;
    }

    $dispatcher->dispatch(new ResponseReceived($this->request, $response));
}
```

The check fails when sending subsequent requests through the HttpSender because the request goes through the underlying handler stack, which uses the beforeSendingCallback not for the current instance, but for the very first one that was built in the HttpSender. 

```php
public function __construct(Factory $factory = null)
{
    // ..
        $pendingRequest->request = $request; // This sets $request to the old $pendingRequest instance
    // ...
```

In the new instance the request property stays null, thus the ResponseReceived event is not dispatched.

### Solution

I was looking for a solution that's similar to the current one in the sense that it only uses ->pushHandlerStack to access all Laravel handlers. I first tried adding the middlewares to the stack before every request and removing them afterwards but the removal part was cumbersome with promises.

The proposed solution uses a new middleware that's added to the guzzle handler stack in the constructor. It invokes the laravel handlers directly from the current PendingRequest instance which is passed to it before sending the request.

I'm not 100% sure by the implementation of the middleware's __invoke method so please let me know if this is acceptable.

Thanks!