### PR TITLE
Fix events not being fired on failed requests

### DIFF
--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -11,7 +11,6 @@ use Illuminate\Http\Client\Factory;
 use Saloon\Contracts\PendingRequest;
 use Saloon\Http\Senders\GuzzleSender;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use Illuminate\Http\Client\ConnectionException;
 use Saloon\Repositories\Body\FormBodyRepository;
@@ -73,19 +72,7 @@ class HttpSender extends GuzzleSender
                 $this->createRequestOptions($pendingRequest)
             );
         } catch (ConnectionException|TransferException $exception) {
-            if ($pendingRequest->isAsynchronous() === false) {
-                // When the exception wasn't a RequestException, we'll throw a fatal
-                // exception as this is likely a ConnectException, but it will
-                // catch any new ones Guzzle release.
-
-                if (! $exception instanceof RequestException) {
-                    throw new FatalRequestException($exception, $pendingRequest);
-                }
-
-                // Otherwise, we'll create a response.
-
-                return $this->createResponse($pendingRequest, $exception->getResponse(), $exception);
-            }
+            throw new FatalRequestException($exception, $pendingRequest);
         }
 
         // When the response is a normal HTTP Client Response, we can create the response

--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -66,6 +66,7 @@ class HttpSender extends GuzzleSender
             // the send method that parses the HTTP options and the Laravel
             // data properly.
 
+            /** @var \Illuminate\Http\Client\Response|\GuzzleHttp\Promise\PromiseInterface */
             $response = $laravelPendingRequest->send(
                 $pendingRequest->getMethod()->value,
                 $pendingRequest->getUrl(),

--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Client\Factory;
 use Saloon\Contracts\PendingRequest;
 use Saloon\Http\Senders\GuzzleSender;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\TransferException;
 use Illuminate\Http\Client\ConnectionException;
 use Saloon\Repositories\Body\FormBodyRepository;
@@ -60,6 +61,7 @@ class HttpSender extends GuzzleSender
             // We need to let Laravel catch and handle HTTP errors to preserve
             // the default behavior. It does so by inspecting the status code
             // instead of catching an exception which is what Saloon does.
+
             $pendingRequest->config()->set([RequestOptions::HTTP_ERRORS => false]);
 
             // We should pass in the request options as there is a call inside
@@ -72,7 +74,7 @@ class HttpSender extends GuzzleSender
                 $pendingRequest->getUrl(),
                 $this->createRequestOptions($pendingRequest)
             );
-        } catch (ConnectionException|TransferException $exception) {
+        } catch (ConnectionException|ConnectException $exception) {
             throw new FatalRequestException($exception, $pendingRequest);
         }
 

--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Saloon\HttpSender;
 
 use Throwable;
+use GuzzleHttp\RequestOptions;
 use Saloon\Contracts\Response;
 use Illuminate\Http\Client\Factory;
 use Saloon\Contracts\PendingRequest;
@@ -56,6 +57,11 @@ class HttpSender extends GuzzleSender
     {
         try {
             $laravelPendingRequest = $this->createLaravelPendingRequest($pendingRequest, $asynchronous);
+
+            // We need to let Laravel catch and handle HTTP errors to preserve
+            // the default behavior. It does so by inspecting the status code
+            // instead of catching an exception which is what Saloon does.
+            $pendingRequest->config()->set([RequestOptions::HTTP_ERRORS => false]);
 
             // We should pass in the request options as there is a call inside
             // the send method that parses the HTTP options and the Laravel

--- a/tests/Feature/HttpEventsTest.php
+++ b/tests/Feature/HttpEventsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Saloon\HttpSender\Tests\Fixtures\Requests\UserRequest;
+use Saloon\HttpSender\Tests\Fixtures\Requests\ErrorRequest;
 use Saloon\HttpSender\Tests\Fixtures\Connectors\HttpSenderConnector;
 
 test('the http events are fired when using the http sender', function () {
@@ -22,11 +23,11 @@ test('the http events are fired when using the http sender', function () {
 
     $responseA = $connector->send(new UserRequest);
     $responseB = $connector->send(new UserRequest);
-    $responseC = $connector->send(new UserRequest);
+    $responseC = $connector->send(new ErrorRequest);
 
     expect($responseA->status())->toBe(200);
     expect($responseB->status())->toBe(200);
-    expect($responseC->status())->toBe(200);
+    expect($responseC->status())->toBe(500);
 
     Event::assertDispatched(RequestSending::class, 3);
     Event::assertDispatched(ResponseReceived::class, 3);

--- a/tests/Feature/HttpEventsTest.php
+++ b/tests/Feature/HttpEventsTest.php
@@ -6,6 +6,7 @@ use Saloon\Contracts\Response;
 use Saloon\HttpSender\HttpSender;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Config;
+use Saloon\Exceptions\Request\RequestException;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
 use Saloon\HttpSender\Tests\Fixtures\Requests\UserRequest;
@@ -44,11 +45,16 @@ test('the http events are fired when using the http sender with asynchronous eve
 
     $responseA = $connector->sendAsync(new UserRequest)->wait();
     $responseB = $connector->sendAsync(new UserRequest)->wait();
-    $responseC = $connector->sendAsync(new UserRequest)->wait();
+
+    try {
+        $connector->sendAsync(new ErrorRequest)->wait();
+    } catch (RequestException $requestException) {
+        $responseC = $requestException->getResponse();
+    }
 
     expect($responseA->status())->toBe(200);
     expect($responseB->status())->toBe(200);
-    expect($responseC->status())->toBe(200);
+    expect($responseC->status())->toBe(500);
 
     Event::assertDispatched(RequestSending::class, 3);
     Event::assertDispatched(ResponseReceived::class, 3);
@@ -66,7 +72,7 @@ test('the http events are fired when using request pools', function () {
     $pool = $connector->pool([
         'a' => new UserRequest,
         'b' => new UserRequest,
-        'c' => new UserRequest,
+        'c' => new ErrorRequest,
     ]);
 
     $responses = [];
@@ -75,11 +81,15 @@ test('the http events are fired when using request pools', function () {
         $responses[$key] = $response;
     });
 
+    $pool->withExceptionHandler(function (RequestException $requestException, string $key) use (&$responses) {
+        $responses[$key] = $requestException->getResponse();
+    });
+
     $pool->send()->wait();
 
     expect($responses['a']->status())->toBe(200);
     expect($responses['b']->status())->toBe(200);
-    expect($responses['c']->status())->toBe(200);
+    expect($responses['c']->status())->toBe(500);
 
     Event::assertDispatched(RequestSending::class, 3);
     Event::assertDispatched(ResponseReceived::class, 3);


### PR DESCRIPTION
Fixes #4 

This is caused by the difference between handling failures in Saloon and Laravel. While Saloon relies on guzzle throwing an exception and catching it, Laravel builds a response from all requests, dispatches events and then decides whether to throw an exception:

https://github.com/laravel/framework/blob/dfb59bc263a4e28ac8992deeabd2ccd9392d1681/src/Illuminate/Http/Client/PendingRequest.php#L823-L851

This is achieved by setting `http_errors` to false [in the constructor](https://github.com/laravel/framework/blob/dfb59bc263a4e28ac8992deeabd2ccd9392d1681/src/Illuminate/Http/Client/PendingRequest.php#L229) 

Saloon sets this to true in the underlying guzzle handler. This causes the code to terminate before dispatching the events. To overcome this I set the setting to false before sending the request. Laravel throws an exception by default on failed requests which is then caught back in the HttpSender.

