### PR TITLE
Fix | Fixed issue with guzzle config options not being sent

### DIFF
--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -62,7 +62,7 @@ class HttpSender extends GuzzleSender
             // the default behavior. It does so by inspecting the status code
             // instead of catching an exception which is what Saloon does.
 
-            $pendingRequest->config()->set([RequestOptions::HTTP_ERRORS => false]);
+            $pendingRequest->config()->merge([RequestOptions::HTTP_ERRORS => false]);
 
             // We should pass in the request options as there is a call inside
             // the send method that parses the HTTP options and the Laravel

--- a/tests/Feature/ConfigTest.php
+++ b/tests/Feature/ConfigTest.php
@@ -1,10 +1,12 @@
 <?php
 
-use GuzzleHttp\Promise\FulfilledPromise;
-use Psr\Http\Message\RequestInterface;
+declare(strict_types=1);
+
 use Saloon\Http\Faking\MockResponse;
-use Saloon\HttpSender\Tests\Fixtures\Connectors\HttpSenderConnector;
+use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Promise\FulfilledPromise;
 use Saloon\HttpSender\Tests\Fixtures\Requests\UserRequest;
+use Saloon\HttpSender\Tests\Fixtures\Connectors\HttpSenderConnector;
 
 test('default guzzle config options are sent', function () {
     $connector = new HttpSenderConnector();

--- a/tests/Feature/ConfigTest.php
+++ b/tests/Feature/ConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use GuzzleHttp\Promise\FulfilledPromise;
+use Psr\Http\Message\RequestInterface;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\HttpSender\Tests\Fixtures\Connectors\HttpSenderConnector;
+use Saloon\HttpSender\Tests\Fixtures\Requests\UserRequest;
+
+test('default guzzle config options are sent', function () {
+    $connector = new HttpSenderConnector();
+
+    $connector->sender()->addMiddleware(function (callable $handler) {
+        return function (RequestInterface $guzzleRequest, array $options) {
+            expect($options)->toHaveKey('http_errors', false);
+            expect($options)->toHaveKey('connect_timeout', 10);
+            expect($options)->toHaveKey('timeout', 30);
+
+            return new FulfilledPromise(MockResponse::make()->getPsrResponse());
+        };
+    });
+
+    $connector->send(new UserRequest);
+});
+
+test('you can pass additional guzzle config options and they are merged from the connector and request', function () {
+    $connector = new HttpSenderConnector();
+
+    $connector->config()->add('debug', true);
+
+    $connector->sender()->addMiddleware(function (callable $handler) {
+        return function (RequestInterface $guzzleRequest, array $options) {
+            expect($options)->toHaveKey('http_errors', false);
+            expect($options)->toHaveKey('connect_timeout', 10);
+            expect($options)->toHaveKey('timeout', 30);
+            expect($options)->toHaveKey('debug', true);
+            expect($options)->toHaveKey('verify', false);
+
+            return new FulfilledPromise(MockResponse::make()->getPsrResponse());
+        };
+    });
+
+    $request = new UserRequest;
+
+    $request->config()->add('verify', false);
+
+    $connector->send($request);
+});
+
+test('the withBasicAuth method can be used to add the auth to the guzzle config', function () {
+    $connector = new HttpSenderConnector();
+
+    $connector->withBasicAuth('Sammyjo20', 'Yeehaw');
+
+    $connector->sender()->addMiddleware(function (callable $handler) {
+        return function (RequestInterface $guzzleRequest, array $options) {
+            expect($options)->toHaveKey('auth', ['Sammyjo20', 'Yeehaw']);
+
+            return new FulfilledPromise(MockResponse::make()->getPsrResponse());
+        };
+    });
+
+    $connector->send(new UserRequest);
+});


### PR DESCRIPTION
This PR fixes an issue where any additional Guzzle configuration items that were sent including ones that were added by authenticator methods like the `withBasicAuth` would get overwritten in the HttpSender class. 

Fixes #7 