### PR TITLE
Bugfix: failed exception treated as successful should not trigger exception in pool

### DIFF
--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -129,9 +129,10 @@ class HttpSender extends GuzzleSender
 
                     $response = $this->createResponse($exception->response->toPsrResponse(), $pendingRequest, $psrRequest, $exception);
 
-                    // Throw the exception our way
+                    // Throw the exception our way if there is an exception.
+                    // Otherwise we'll return the response.
 
-                    throw $response->toException();
+                    return ($exception = $response->toException()) ? throw $exception : $response;
                 }
             );
     }

--- a/tests/Fixtures/Requests/ErrorRequestThatShouldBeTreatedAsSuccessful.php
+++ b/tests/Fixtures/Requests/ErrorRequestThatShouldBeTreatedAsSuccessful.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\HttpSender\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class ErrorRequestThatShouldBeTreatedAsSuccessful extends Request
+{
+    /**
+     * HTTP Method
+     */
+    protected Method $method = Method::GET;
+
+    /**
+     * Resolve the endpoint
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/not-found-error';
+    }
+
+    public function hasRequestFailed(Response $response): ?bool
+    {
+        return $response->status() !== 404;
+    }
+}


### PR DESCRIPTION
Linked to https://github.com/saloonphp/saloon/pull/314 (test will succeed when code of that PR is merged)

If a failed response should not be treated as failure because the `hasRequestFailed` returns false, then the Laravel Http Sender currently throws a `Can only throw objects` PHP error. That is caused by the fact that the `toException()` method on the response returns null and you can not throw null.