### PR TITLE
Merge the existing headers from the Config Store

### DIFF
--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -155,7 +155,10 @@ class HttpSender extends GuzzleSender
         // deal with PSR requests. We'll add the headers from the PSR
         // request to ensure the lowest-level values possible.
 
-        $config->add(RequestOptions::HEADERS, $psrRequest->getHeaders());
+        $config->add(RequestOptions::HEADERS, array_merge(
+            $psrRequest->getHeaders(),
+            $config->get(RequestOptions::HEADERS, [])
+        ));
 
         return $config->all();
     }


### PR DESCRIPTION
In the `createRequestOptions()` method of the `HttpSender` class, the headers from the _PSR Request_ are added to the config store. This would overwrite any headers that have already been set on the config, for example, from the `defaultConfig()` method of a Connector.

With this PR, it merges both the PSR Request headers _and_ headers that already were present in the config store.