### PR TITLE
Apply global middleware also to Saloon requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,11 +20,9 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         php: [ 8.1, 8.2 ]
-        laravel: [ 9.*, 10.* ]
+        laravel: [ 10.* ]
         stability: [ prefer-lowest, prefer-stable ]
         include:
-          - laravel: 9.*
-            testbench: 7.*
           - laravel: 10.*
             testbench: 8.*
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/sammyjo20",
     "require": {
         "php": "^8.1",
-        "illuminate/http": "^9.52 || ^10.0",
+        "illuminate/http": "^10.32",
         "saloonphp/saloon": "^3.0"
     },
     "require-dev": {
@@ -21,7 +21,7 @@
         "pestphp/pest": "^1.23",
         "phpstan/phpstan": "^1.9",
         "spatie/ray": "^1.33",
-        "orchestra/testbench": "^7.30 || ^8.0"
+        "orchestra/testbench": "^8.0"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/http": "^10.32",
-        "saloonphp/saloon": "^3.0"
+        "saloonphp/saloon": "^3.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.5",

--- a/src/HttpPendingRequest.php
+++ b/src/HttpPendingRequest.php
@@ -15,9 +15,9 @@ class HttpPendingRequest extends PendingRequest
     /**
      * Constructor
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(Factory $factory = null, $middleware = [])
     {
-        parent::__construct($factory);
+        parent::__construct($factory, $middleware);
 
         $this->options = [];
     }

--- a/src/HttpPendingRequest.php
+++ b/src/HttpPendingRequest.php
@@ -14,6 +14,8 @@ class HttpPendingRequest extends PendingRequest
 {
     /**
      * Constructor
+     *
+     * @param array<int, callable> $middleware
      */
     public function __construct(Factory $factory = null, $middleware = [])
     {

--- a/src/HttpPendingRequest.php
+++ b/src/HttpPendingRequest.php
@@ -17,7 +17,7 @@ class HttpPendingRequest extends PendingRequest
      *
      * @param array<int, callable> $middleware
      */
-    public function __construct(Factory $factory = null, $middleware = [])
+    public function __construct(Factory $factory = null, array $middleware = [])
     {
         parent::__construct($factory, $middleware);
 

--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -56,7 +56,7 @@ class HttpSender extends GuzzleSender
                 (string)$psrRequest->getUri(),
                 $this->createRequestOptions($pendingRequest, $psrRequest),
             );
-        } catch (ConnectionException|ConnectException $exception) {
+        } catch (ConnectionException | ConnectException $exception) {
             throw new FatalRequestException($exception, $pendingRequest);
         }
 
@@ -170,10 +170,6 @@ class HttpSender extends GuzzleSender
     {
         /** @var Factory $httpFactory */
         $httpFactory = resolve(Factory::class);
-
-        if (! $httpFactory->hasMacro('getGlobalMiddleware')) {
-            $httpFactory->macro('getGlobalMiddleware', fn () => $this->globalMiddleware ?? []);
-        }
 
         $httpPendingRequest = new HttpPendingRequest($httpFactory, $httpFactory->getGlobalMiddleware());
         $httpPendingRequest->setClient($this->client);

--- a/src/HttpSender.php
+++ b/src/HttpSender.php
@@ -165,7 +165,14 @@ class HttpSender extends GuzzleSender
      */
     protected function createLaravelPendingRequest(RequestInterface $psrRequest, bool $asynchronous): HttpPendingRequest
     {
-        $httpPendingRequest = new HttpPendingRequest(resolve(Factory::class));
+        /** @var Factory $httpFactory */
+        $httpFactory = resolve(Factory::class);
+
+        if (! $httpFactory->hasMacro('getGlobalMiddleware')) {
+            $httpFactory->macro('getGlobalMiddleware', fn () => $this->globalMiddleware ?? []);
+        }
+
+        $httpPendingRequest = new HttpPendingRequest($httpFactory, $httpFactory->getGlobalMiddleware());
         $httpPendingRequest->setClient($this->client);
 
         $this->laravelMiddleware->setRequest($httpPendingRequest);

--- a/tests/Feature/GlobalMiddlewareTest.php
+++ b/tests/Feature/GlobalMiddlewareTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\HttpSender\HttpSender;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Config;
+use Saloon\HttpSender\Tests\Fixtures\Requests\UserRequest;
+use Saloon\HttpSender\Tests\Fixtures\Connectors\HttpSenderConnector;
+
+test('the global middleware of the http client factory is also applied to saloon requests', function () {
+    Config::set('saloon.default_sender', HttpSender::class);
+
+    $globalMiddlewareWasCalled = false;
+
+    Http::globalRequestMiddleware(function ($request) use (&$globalMiddlewareWasCalled) {
+        $globalMiddlewareWasCalled = true;
+
+        return $request;
+    });
+
+    $connector = new HttpSenderConnector;
+    $connector->send(new UserRequest);
+
+    expect($globalMiddlewareWasCalled)->toBeTrue();
+});


### PR DESCRIPTION
In [Laravel 10.14](https://laravel-news.com/laravel-10-14-0), Global HTTP middleware was introduced ([PR #47525](https://github.com/laravel/framework/pull/47525)). You may use this to globally set a default User Agent. The Middleware array is passed from the _HTTP Factory_ to a new `PendingRequest`:

https://github.com/laravel/framework/blob/fc8f819bef5b4843baadda393c51320ceeb41a70/src/Illuminate/Http/Client/Factory.php#L396-L404

In the `createLaravelPendingRequest()` method of `HttpSender`, a new `PendingRequest` is instantiated but without the global middleware. This PR fixes that. 

One caveat, though: there's no functionality to grab the middleware array from the Factory. So as a workaround, I added a macro. After opening this PR, I'll submit another PR to the Laravel repository to do this more elegantly.