### PR TITLE
Fix PHP 8.4 implicit nullable deprecation

### DIFF
--- a/src/HttpPendingRequest.php
+++ b/src/HttpPendingRequest.php
@@ -17,7 +17,7 @@ class HttpPendingRequest extends PendingRequest
      *
      * @param array<int, callable> $middleware
      */
-    public function __construct(Factory $factory = null, array $middleware = [])
+    public function __construct(?Factory $factory = null, array $middleware = [])
     {
         parent::__construct($factory, $middleware);
 


### PR DESCRIPTION
Using PHP 8.4, this package emits the following deprecation warning:
```
DEPRECATED  Saloon\HttpSender\HttpPendingRequest::__construct(): Implicitly marking parameter $factory as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/saloonphp/laravel-http-sender/src/HttpPendingRequest.php on line 20.
```

This PR is aimed to fix this issue.